### PR TITLE
Feature/add terms of use page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1087,7 +1087,7 @@
       <ul class="footer-list">
 
         <li>
-          <a href="#" class="footer-link">Terms of use</a>
+          <a href="./terms-of-use.html" class="footer-link">Terms of use</a>
         </li>
 
         <li>

--- a/terms-of-use.html
+++ b/terms-of-use.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WildGuard - Terms of Use</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+  <style>
+
+    /* Modify Bootstrap components with the base color and its shades */
+    body {
+      background-color: #f5f5f5;  /* Light background */
+    }
+
+    .h2, h3, p {
+      color: #333;  /* Darker text for better readability */
+    }
+
+    .h2 {
+      border-bottom: 1px solid #2ecc71;
+      padding-bottom: 10px;
+      margin-bottom: 20px;
+    }
+
+    .h3 {
+      margin-bottom: 10px;
+    }
+
+    .text-justify {
+      text-align: justify;
+      line-height: 1.5;
+    }  /* Adjust line height for better readability */
+
+    /* Optional: Style other Bootstrap components as needed */
+    .container {
+      border: 1px solid #ddd;  /* Subtle border */
+      padding: 20px;
+      border-radius: 5px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container mt-5">
+    <div class="row">
+      <div class="col-md-12">
+        <h2 class="h2 text-center mb-4">Terms of Use</h2>
+
+        <h3 class="h3">Disclaimers</h3>
+        <p class="text-justify">
+          The WildGuard platform is provided on an "as is" and "as available" basis, without any warranties of any kind, either express or implied, including but not limited to implied warranties of merchantability, fitness for a particular purpose, or non-infringement. We do not guarantee that the platform will be uninterrupted, secure, or free from errors or inaccuracies. The content provided on WildGuard is for general informational purposes only and does not constitute legal, professional, or other advice. You should consult a qualified professional for guidance specific to your situation before acting based on the content available on the platform.
+        </p>
+
+        <h3 class="h3">Limitation of Liability</h3>
+        <p class="text-justify">
+          In no event shall WildGuard, its affiliates, officers, directors, employees, agents, or licensors be liable for any damages resulting from your use of the platform, including but not limited to direct, indirect, incidental, consequential, or special damages, such as loss of profits, data, or goodwill, even if we have been informed of the possibility of such damages. This limitation of liability applies to all actions and claims related to the use or performance of the platform.
+        </p>
+
+        <h3 class="h3">Indemnification</h3>
+        <p class="text-justify">
+          You agree to indemnify, defend, and hold harmless WildGuard, its affiliates, officers, directors, employees, agents, and licensors from and against all claims, liabilities, damages, losses, expenses, and costs, including reasonable legal fees, arising out of your use of the platform, your violation of these Terms, or your infringement of any third-party rights.
+        </p>
+      </div>
+    </div>
+  </div>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
---
#48 
### **Pull Request Title:**
Added "Terms of Use" page and linked it in the main HTML file

###**Screenshots:**
![Screenshot (13)](https://github.com/user-attachments/assets/fb476f09-8ace-4533-8a3e-c162d02825ab)
![Screenshot (14)](https://github.com/user-attachments/assets/560eb478-324f-49f9-9ce7-f0ce8c2d3ae3)



### **Pull Request Description:**
This PR adds a new "Terms of Use" page (`terms-of-use.html`) to the project and links it to the main HTML file. Key changes include:

- Created a new `terms-of-use.html` file that contains a basic structure for the terms and conditions.
- Added placeholder content that can be modified with actual terms at a later stage.
- Updated the main HTML (`index.html`) to include a link in the footer/header that navigates users to the "Terms of Use" page.

These changes will ensure that users can access the "Terms of Use" section to understand the guidelines for using the app.

Let me know if you'd like any adjustments!