### PR TITLE
Added image carousel on banner-row for smaller screen width devices ISSUE #42

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -517,7 +517,20 @@ body {
   max-width: max-content;
   margin-block-end: 30px;
 }
-
+.banner-imgs
+{
+  display: grid;
+  scale: calc(100px/100%);
+}
+.banner-img-container
+{
+  display: flex;
+}
+.about-img
+{
+  object-fit: contain;
+  border-radius: 8px;
+}
 .about .section-subtitle {
   margin-block-end: 10px;
 }
@@ -1291,23 +1304,6 @@ body {
    * ABOUT
    */
 
-  .banner-col {
-    width: 50%;
-  }
-
-  .about-img {
-    max-width: 100%;
-  }
-
-  .about-img-2 {
-    min-width: 120%;
-    margin-inline-start: -20%;
-  }
-
-  .about-img-3 {
-    max-width: 90%;
-  }
-
   .about .container {
     display: grid;
     grid-template-columns: 1fr 0.8fr;
@@ -1319,6 +1315,46 @@ body {
     margin-block-end: 0;
   }
 
+  .banner-img-cont-1
+  {
+    grid-area: tiger;
+    align-items: end;
+  }
+  .banner-img-cont-2
+  {
+    grid-area: elephant;
+    align-items: end;
+    justify-content: start;
+  }
+  .banner-img-cont-2 .about-img
+  {
+    height: 16vw;
+    width: auto;
+  }
+
+  .banner-img-cont-3
+  {
+    grid-area: panda;
+    align-items: start;
+  }
+  .banner-img-cont-4
+  {
+    grid-area: deer;
+    align-items: start;
+  }
+  .banner-imgs
+  {
+    display: grid;
+    grid-template: 16vw 4vw 16vw/ 4vw 16vw 16vw 2vw;
+    gap: 2vmin;
+    grid-template-areas: 
+    ". tiger elephant ."
+    ". tiger deer deer"
+    "panda panda deer deer"
+    ;
+    position: relative;
+  }
+  
   /**
    * CTA
    */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -488,6 +488,7 @@ body {
   position: relative;
   max-width: max-content;
   margin-block-end: 30px;
+  margin: auto;
 }
 
 .deco-title {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -525,6 +525,8 @@ body {
   display: flex;
 }
 .about-img {
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   border-radius: 8px;
 }
@@ -583,6 +585,50 @@ body {
 
 .about .section-subtitle {
   margin-block-end: 10px;
+}
+
+.banner-carousel
+{
+  display: flex;
+  gap: 2vmin;
+  scale: calc(100px/100%);
+  width: 80%;
+  height: 50vh;
+  margin: auto;
+  position: relative;
+}
+
+.banner-carousel-frame
+{
+  position: absolute;
+  top: 0;
+  left: 0;
+ height: 100%;  
+ width: 100%;  
+ overflow: hidden; 
+ opacity: 0;
+ visibility: hidden;
+ transition: opacity 0.5s ease, visibility 0.5s ease;
+}
+
+.banner-carousel-frame.active
+{
+  opacity: 1;
+  visibility: visible;
+  z-index: 1;
+}
+
+.banner-carousel-frame.hidden
+{
+  opacity: 0;
+  z-index: 0;
+  visibility: hidden;
+}
+
+.banner-img-cont-1
+{
+  opacity: 1;
+  visibility: visible;
 }
 
 .tab-nav {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -344,7 +344,7 @@ body {
 .navbar.active {
   transform: translateY(-100%);
 
-  visibility: visible; 
+  visibility: visible;
 
   visibility: visible;
   width: 100vw;
@@ -517,23 +517,20 @@ body {
   max-width: max-content;
   margin-block-end: 30px;
 }
-.banner-imgs
-{
+.banner-imgs {
   display: grid;
-  scale: calc(100px/100%);
+  scale: calc(100px / 100%);
 }
-.banner-img-container
-{
+.banner-img-container {
   display: flex;
 }
-.about-img
-{
+.about-img {
   object-fit: contain;
   border-radius: 8px;
 }
 
-
-.prev-btn, .next-btn {
+.prev-btn,
+.next-btn {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
@@ -550,27 +547,25 @@ body {
 
 .prev-btn {
   left: calc(-1 * min(32px, 8vw));
-
 }
 
 .next-btn {
   right: calc(-1 * min(32px, 8vw));
 }
 
-.prev-btn:hover, .next-btn:hover {
+.prev-btn:hover,
+.next-btn:hover {
   background-color: rgba(0, 0, 0, 0.8);
 }
-.spot-circles{
+.spot-circles {
   display: flex;
   width: 70vw;
   margin: auto;
   justify-content: center;
   gap: 5px;
-
 }
 
-.circle
-{
+.circle {
   height: 15px;
   width: 15px;
   border-radius: 50%;
@@ -582,8 +577,7 @@ body {
   margin-top: 20px;
 }
 
-.spot-circles span[index="1"]
-{
+.spot-circles span[index="1"] {
   background-color: #000;
 }
 
@@ -727,15 +721,12 @@ body {
   transition: font-size 0.2s ease; /* Smooth transition */
 }
 
-
 .btn-link:hover {
   font-size: calc(var(--fs-8) * 0.9); /* Shrink text size by 10% on hover */
 }
-.btn-link span { text-decoration: underline; }
-
-
-
-
+.btn-link span {
+  text-decoration: underline;
+}
 
 /*-----------------------------------*\
   #DONATE
@@ -902,11 +893,9 @@ body {
 }
 
 .partner-logo:is(:hover, :focus) .color,
-
-.partner-logo .gray { display: block; }
-
-
-
+.partner-logo .gray {
+  display: block;
+}
 
 .become_partner {
   display: inline-flex; /* Use flex for alignment */
@@ -921,12 +910,9 @@ body {
   transform: scale(1.05); /* Slightly enlarge on hover */
 }
 
-
 .become_partner ion-icon {
   margin-left: 8px; /* Space between text and icon */
 }
-
-
 
 /*-----------------------------------*\
   #EVENT
@@ -1362,7 +1348,7 @@ body {
 
   .about .container {
     display: grid;
-    grid-template-columns: 1fr 0.8fr;
+    grid-template-columns: 1fr 1fr;
     align-items: flex-start;
     gap: 120px;
   }
@@ -1371,46 +1357,48 @@ body {
     margin-block-end: 0;
   }
 
-  .banner-img-cont-1
-  {
+  .banner-img-cont-1 {
     grid-area: tiger;
     align-items: end;
   }
-  .banner-img-cont-2
-  {
+  .banner-img-cont-2 {
     grid-area: elephant;
     align-items: end;
     justify-content: start;
   }
-  .banner-img-cont-2 .about-img
-  {
+  .banner-img-cont-2 .about-img {
     height: 16vw;
     width: auto;
   }
 
-  .banner-img-cont-3
-  {
+  .banner-img-cont-3 {
     grid-area: panda;
     align-items: start;
   }
-  .banner-img-cont-4
-  {
+  .banner-img-cont-4 {
     grid-area: deer;
     align-items: start;
   }
-  .banner-imgs
-  {
+  .banner-imgs {
     display: grid;
     grid-template: 16vw 4vw 16vw/ 4vw 16vw 16vw 2vw;
     gap: 2vmin;
-    grid-template-areas: 
-    ". tiger elephant ."
-    ". tiger deer deer"
-    "panda panda deer deer"
-    ;
+    grid-template-areas:
+      ". tiger elephant ."
+      ". tiger deer deer"
+      "panda panda deer deer";
     position: relative;
   }
-  
+
+  .prev-btn,
+  .next-btn,
+  .spot-circles {
+    display: none;
+  }
+  .banner-img-container {
+    opacity: 1;
+    visibility: visible;
+  }
   /**
    * CTA
    */
@@ -1537,19 +1525,16 @@ body {
     transition: var(--transition-2); /* Smooth transition */
     background: none; /* No background */
   }
-  
+
   .lang-switch:is(:hover, :focus) {
     background: none; /* No background on hover or focus */
     outline: none; /* Removes default outline */
     color: var(--primary-color); /* Optional color change on focus or hover */
   }
-  
+
   .lang-switch-group:hover .lang-switch:not(:hover) {
     color: var(--white-60); /* Dim color of select box when it's not hovered */
   }
-  
-
-
 
   .lang-switch option {
     color: var(--eerie-black-1);
@@ -1661,7 +1646,7 @@ body {
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
   transition: background-color 0.3s, transform 0.3s;
   font-size: 24px; /* Larger icon */
-  z-index:1;
+  z-index: 1;
 }
 
 #btn-back-to-top:hover {
@@ -1681,7 +1666,9 @@ body {
   top: 50%;
   right: 20%;
   transform: translateY(-50%);
-  background-color: var(--baby-powder); /* Light background matching page theme */
+  background-color: var(
+    --baby-powder
+  ); /* Light background matching page theme */
   border: 1px solid var(--pistachio); /* Border to match the pistachio theme */
   border-radius: 5px;
   padding: 5px;
@@ -1694,7 +1681,9 @@ body {
 /* Remove default outline for the search input */
 .search-bar input:focus {
   outline: none; /* Removes the default black outline */
-  border-color: var(--pistachio); /* Optionally, add a custom border color on focus */
+  border-color: var(
+    --pistachio
+  ); /* Optionally, add a custom border color on focus */
   box-shadow: 0 0 5px rgba(0, 255, 0, 0.5); /* Optional: Add a subtle shadow to show focus */
 }
 
@@ -1719,7 +1708,10 @@ body {
   font-size: 1.2rem;
 }
 
-#prevMatch, #nextMatch, #clearSearch, #closeSearch {
+#prevMatch,
+#nextMatch,
+#clearSearch,
+#closeSearch {
   background-color: var(--pistachio); /* Button background */
   color: var(--white); /* Button text color */
   border: none;
@@ -1729,7 +1721,10 @@ body {
   cursor: pointer;
 }
 
-#prevMatch:hover, #nextMatch:hover, #clearSearch:hover, #closeSearch:hover {
+#prevMatch:hover,
+#nextMatch:hover,
+#clearSearch:hover,
+#closeSearch:hover {
   background-color: var(--granite-gray); /* Darker hover effect for buttons */
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -536,8 +536,7 @@ body {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background-color: rgba(0, 0, 0, 0.5);
-  color: white;
+  color: var(--pistachio);
   border: none;
   padding: 10px;
   cursor: pointer;
@@ -557,7 +556,7 @@ body {
 
 .prev-btn:hover,
 .next-btn:hover {
-  background-color: rgba(0, 0, 0, 0.8);
+  /* background-color: rgba(0, 0, 0, 0.8); */
 }
 .spot-circles {
   display: flex;
@@ -568,8 +567,8 @@ body {
 }
 
 .circle {
-  height: 15px;
-  width: 15px;
+  height: 12px;
+  width: 12px;
   border-radius: 50%;
   -webkit-border-radius: 50%;
   -moz-border-radius: 50%;
@@ -580,7 +579,7 @@ body {
 }
 
 .spot-circles span[index="1"] {
-  background-color: #000;
+  background-color: var(--pistachio_50);
 }
 
 .about .section-subtitle {
@@ -1179,7 +1178,7 @@ body {
   {
    display: flex;
   }
-  
+
   /* .deco-title {
     left: 0% !important;
   } */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1404,9 +1404,11 @@ body {
     align-items: flex-start;
     gap: 120px;
   }
-
+  
   .about-banner {
     margin-block-end: 0;
+    height: 100%;
+    padding: var(--fs-4) 0;
   }
 
   .banner-img-cont-1 {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -509,14 +509,11 @@ body {
 .deco-img {
   position: absolute;
   top: -40px;
-  left: 0;
+  transform: translate(80%, -16%); 
   z-index: -1;
 }
 
-.about-img {
-  max-width: max-content;
-  margin-block-end: 30px;
-}
+
 .banner-imgs {
   display: grid;
   scale: calc(100px / 100%);
@@ -556,7 +553,7 @@ body {
 
 .prev-btn:hover,
 .next-btn:hover {
-  /* background-color: rgba(0, 0, 0, 0.8); */
+  color: var(--black);
 }
 .spot-circles {
   display: flex;
@@ -602,12 +599,12 @@ body {
   position: absolute;
   top: 0;
   left: 0;
- height: 100%;  
- width: 100%;  
- overflow: hidden; 
- opacity: 0;
- visibility: hidden;
- transition: opacity 0.5s ease, visibility 0.5s ease;
+  height: 100%;  
+  width: 100%;  
+  overflow: hidden; 
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.5s ease, visibility 0.5s ease;
 }
 
 .banner-carousel-frame.active
@@ -1277,7 +1274,7 @@ body {
 
   .deco-title {
     top: 10%;
-    /* left: calc(100% + 40px); */
+    left: calc(100% + 40px);
   }
 
   .about-img {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1171,6 +1171,15 @@ body {
     --fs-4: 4.1rem;
   }
 
+  .prev-btn, .next-btn
+  {
+    display: block;
+  }
+  .spot-circles
+  {
+   display: flex;
+  }
+  
   /* .deco-title {
     left: 0% !important;
   } */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -531,6 +531,62 @@ body {
   object-fit: contain;
   border-radius: 8px;
 }
+
+
+.prev-btn, .next-btn {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.5);
+  color: white;
+  border: none;
+  padding: 10px;
+  cursor: pointer;
+  z-index: 2;
+  font-size: var(--fs-8);
+  border-radius: 8px;
+  margin: 0 -6%;
+}
+
+.prev-btn {
+  left: calc(-1 * min(32px, 8vw));
+
+}
+
+.next-btn {
+  right: calc(-1 * min(32px, 8vw));
+}
+
+.prev-btn:hover, .next-btn:hover {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+.spot-circles{
+  display: flex;
+  width: 70vw;
+  margin: auto;
+  justify-content: center;
+  gap: 5px;
+
+}
+
+.circle
+{
+  height: 15px;
+  width: 15px;
+  border-radius: 50%;
+  -webkit-border-radius: 50%;
+  -moz-border-radius: 50%;
+  -ms-border-radius: 50%;
+  -o-border-radius: 50%;
+  border: 1px solid #00000077;
+  margin-top: 20px;
+}
+
+.spot-circles span[index="1"]
+{
+  background-color: #000;
+}
+
 .about .section-subtitle {
   margin-block-end: 10px;
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -281,13 +281,14 @@ function next()
 }
 
 function prev() {
-  currItem.style.display = "none";
+  currItem.classList.remove('active');
+  currItem.classList.add('hidden');
   if(currItem.previousElementSibling && currItem.previousElementSibling.tagName != "BUTTON")
       currItem = currItem.previousElementSibling;
   else
       currItem = cover.children[n-2];
-  currItem.style.display = "block";
-
+  currItem.classList.remove("hidden");
+  currItem.classList.add("active");
   updateDot(currItem.getAttribute('index'));
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -298,7 +298,7 @@ function updateDot(index)
     const prevDot = document.querySelector(`span[index="${((index-2+4)%4+1)}"]`);
     const nextDot = document.querySelector(`span[index="${(parseInt(index))%4+1}"]`);
 
-    dot.setAttribute('style', 'background-color: #000; border-color: #000;');
+    dot.setAttribute('style', 'background-color: hsla(86, 45%, 54%, 0.5); border-color: #000;');
    
     [prevDot, nextDot].forEach(dot => 
         dot.setAttribute('style', 'background-color: transparent; border-color: #00000077;')

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -258,3 +258,123 @@ function hideNavigationButtons() {
   clearSearchBtn.style.display = "none";
   matchCounter.style.display = "none";
 }
+
+
+// Toggle Image carousel for smaller width devices
+
+const cover = document.querySelector('.banner-imgs');
+let currItem = cover.children[1];
+let n = cover.children.length;
+
+function next()
+{
+  currItem.classList.remove('active');
+  currItem.classList.add('hidden');
+
+  if(currItem.nextElementSibling && currItem.nextElementSibling.tagName != "BUTTON")
+      currItem = currItem.nextElementSibling;
+  else
+    currItem = cover.children[1];
+  currItem.classList.remove("hidden");
+  currItem.classList.add("active");
+  updateDot(currItem.getAttribute('index'))
+}
+
+function prev() {
+  currItem.style.display = "none";
+  if(currItem.previousElementSibling && currItem.previousElementSibling.tagName != "BUTTON")
+      currItem = currItem.previousElementSibling;
+  else
+      currItem = cover.children[n-2];
+  currItem.style.display = "block";
+
+  updateDot(currItem.getAttribute('index'));
+}
+
+function updateDot(index)
+{
+    const dot = document.querySelector(`span[index="${index}"]`);
+    const prevDot = document.querySelector(`span[index="${((index-2+4)%4+1)}"]`);
+    const nextDot = document.querySelector(`span[index="${(parseInt(index))%4+1}"]`);
+
+    dot.setAttribute('style', 'background-color: #000; border-color: #000;');
+   
+    [prevDot, nextDot].forEach(dot => 
+        dot.setAttribute('style', 'background-color: transparent; border-color: #00000077;')
+    );
+
+
+}
+
+const nextBtn = document.querySelector(".next-btn");
+const prevBtn = document.querySelector(".prev-btn");
+
+nextBtn.addEventListener("click",()=> 
+    {   clearInterval(intervalID);
+        next();
+        intervalID = setInterval(next, 2000);
+        
+    });
+
+prevBtn.addEventListener("click", ()=>{
+    clearInterval(intervalID);
+    prev();
+    intervalID = setInterval(next, 2400);
+
+});
+
+
+const circleBtns = document.querySelectorAll('.circle');
+
+circleBtns.forEach(circBtn => {
+    circBtn.addEventListener("click", ()=>{
+        const btnIndex = circBtn.getAttribute('index');
+
+        while(currItem.getAttribute('index') != btnIndex)
+            next();
+        clearInterval(intervalID);
+        intervalID = setInterval(next, 2000);
+    });
+});
+
+
+let intervalID;
+
+const startCarousel = function initiate() {
+    intervalID = setInterval(next, 2000);
+};
+
+
+function checkScreenSize() {
+  const screenWidth = window.innerWidth;
+  if (screenWidth <= 992) {
+    const container = document.querySelector(".banner-imgs");
+    container.classList.add("banner-carousel");
+    const elements = document.querySelectorAll(".banner-img-container");
+    elements.forEach((element) => {
+      element.classList.add("banner-carousel-frame");
+    })
+    const interval_id = window.setInterval(function(){}, Number.MAX_SAFE_INTEGER);
+    for (let i = 1; i < interval_id; i++) {
+      window.clearInterval(i);
+    }
+    startCarousel();
+  }
+ else
+ {
+  const elements = document.querySelectorAll(".banner-img-container");
+  elements.forEach((element) => {
+    element.classList.remove("banner-carousel-frame");
+  const container = document.querySelector(".banner-imgs");
+  container.classList.remove("banner-carousel");
+  })
+  
+  const interval_id = window.setInterval(function(){}, Number.MAX_SAFE_INTEGER);
+  for (let i = 1; i < interval_id; i++) {
+    window.clearInterval(i);
+  }
+ }
+}
+checkScreenSize();
+
+window.addEventListener('resize', checkScreenSize);

--- a/index.html
+++ b/index.html
@@ -297,7 +297,7 @@
                 <!-- Previous button -->
                 <button class="prev-btn">&#10094;</button>
 
-              <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
+              <div class="banner-img-container banner-carousel-frame banner-img-cont-1" index=1>
                   <img
                     src="./assets/images/about-banner-1.jpg"
                     width="315"
@@ -307,7 +307,7 @@
                     class="about-img w-100"
                   />
                 </div>
-                <div class="banner-img-container banner-carousel-frame banner-img-cont-2">
+                <div class="banner-img-container banner-carousel-frame banner-img-cont-2" index=2>
                   <img
                   src="./assets/images/about-banner-3.jpg"
                   width="250"
@@ -318,7 +318,7 @@
                 />
                 </div>
 
-                <div class="banner-img-container banner-carousel-frame banner-img-cont-3">
+                <div class="banner-img-container banner-carousel-frame banner-img-cont-3" index=3>
                   <img
                   src="./assets/images/about-banner-2.jpg"
                   width="386"
@@ -329,7 +329,7 @@
                 />
                   </div>
 
-                  <div class="banner-img-container banner-carousel-frame banner-img-cont-4">
+                  <div class="banner-img-container banner-carousel-frame banner-img-cont-4" index=4>
                   <img
                     src="./assets/images/about-banner-4.jpg"
                     width="315"

--- a/index.html
+++ b/index.html
@@ -292,8 +292,8 @@
                 class="deco-img"
               />
 
-              <div class="banner-row">
-                <div class="banner-col">
+              <div class="banner-imgs banner-carousel">
+              <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
                   <img
                     src="./assets/images/about-banner-1.jpg"
                     width="315"
@@ -302,7 +302,8 @@
                     alt="Tiger"
                     class="about-img w-100"
                   />
-
+                </div>
+                <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
                   <img
                     src="./assets/images/about-banner-2.jpg"
                     width="386"
@@ -311,9 +312,10 @@
                     alt="Panda"
                     class="about-img about-img-2 w-100"
                   />
+             
                 </div>
 
-                <div class="banner-col">
+                <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
                   <img
                     src="./assets/images/about-banner-3.jpg"
                     width="250"
@@ -322,7 +324,9 @@
                     alt="Elephant"
                     class="about-img about-img-3 w-100"
                   />
+                  </div>
 
+                  <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
                   <img
                     src="./assets/images/about-banner-4.jpg"
                     width="315"
@@ -331,8 +335,9 @@
                     alt="Deer"
                     class="about-img w-100"
                   />
-                </div>
+                  </div>
               </div>
+
             </div>
 
 

--- a/index.html
+++ b/index.html
@@ -303,30 +303,29 @@
                     class="about-img w-100"
                   />
                 </div>
-                <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
+                <div class="banner-img-container banner-carousel-frame banner-img-cont-2">
                   <img
-                    src="./assets/images/about-banner-2.jpg"
-                    width="386"
-                    height="250"
-                    loading="lazy"
-                    alt="Panda"
-                    class="about-img about-img-2 w-100"
-                  />
-             
+                  src="./assets/images/about-banner-3.jpg"
+                  width="250"
+                  height="277"
+                  loading="lazy"
+                  alt="Elephant"
+                  class="about-img w-100"
+                />
                 </div>
 
-                <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
+                <div class="banner-img-container banner-carousel-frame banner-img-cont-3">
                   <img
-                    src="./assets/images/about-banner-3.jpg"
-                    width="250"
-                    height="277"
-                    loading="lazy"
-                    alt="Elephant"
-                    class="about-img about-img-3 w-100"
-                  />
+                  src="./assets/images/about-banner-2.jpg"
+                  width="386"
+                  height="250"
+                  loading="lazy"
+                  alt="Panda"
+                  class="about-img w-100"
+                />
                   </div>
 
-                  <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
+                  <div class="banner-img-container banner-carousel-frame banner-img-cont-4">
                   <img
                     src="./assets/images/about-banner-4.jpg"
                     width="315"

--- a/index.html
+++ b/index.html
@@ -353,10 +353,6 @@
 
             </div>
 
-
-
-          
-
           <div class="about-content">
 
             <p class="section-subtitle">

--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
 
               <li>
 
-                <button class="tab-btn active" onclick="our_mission()" id="ourMission">Our Mission</button>
+                <!-- <button class="tab-btn active" onclick="our_mission()" id="ourMission">Our Mission</button> -->
 
                 <button class="tab-btn active btn btn-primary">Our Mission</button>
 
@@ -408,31 +408,6 @@
                 sustainability of our programs.
 
               </p>
-
-              <h2 class="h2 section-title">
-                Rise Your Hand to Save <strong>World Animals Life</strong>
-              </h2>
-
-              <ul class="tab-nav">
-                <li>
-                  <button class="tab-btn active">Our Mission</button>
-                </li>
-
-                <li>
-                  <button class="tab-btn">Our Vision</button>
-                </li>
-
-                <li>
-                  <button class="tab-btn">Next Plan</button>
-                </li>
-              </ul>
-
-              <div class="tab-content">
-                <p class="section-text">
-                  But I must explain to you how all this mistaken denouncing
-                  pleasure and praising pain was born and I will give you a
-                  complete account of the system expoundmaster
-                </p>
 
                 <ul class="tab-list">
                   <li class="tab-item">

--- a/index.html
+++ b/index.html
@@ -293,6 +293,10 @@
               />
 
               <div class="banner-imgs banner-carousel">
+                
+                <!-- Previous button -->
+                <button class="prev-btn">&#10094;</button>
+
               <div class="banner-img-container banner-carousel-frame banner-img-cont-1">
                   <img
                     src="./assets/images/about-banner-1.jpg"
@@ -335,6 +339,16 @@
                     class="about-img w-100"
                   />
                   </div>
+                  
+                  <!-- Next button -->
+                  <button class="next-btn">&#10095;</button>
+              </div>
+              
+              <div class="spot-circles">
+                <span class="circle" index="1"></span>
+                <span class="circle" index="2"></span>
+                <span class="circle" index="3"></span>
+                <span class="circle" index="4"></span>
               </div>
 
             </div>

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
 
 
 
-          </div>
+          
 
           <div class="about-content">
 


### PR DESCRIPTION
On smaller screen devices, the about page banner images looked flat and in a single column, Making the UI look bad and inconvenient.  #42 
Instead of making users scroll through images, I added an interactive carousel to about page banner.
# Before:
![image](https://github.com/user-attachments/assets/823b28a8-1b08-41d9-af6d-cc5aa08ee73a)
# After:
![image](https://github.com/user-attachments/assets/b51ff968-1c97-4a99-96b8-084149550d94)

## Additional changes done:
- [x] Changed about banner structure from row/column to grid to make it more flexible
- [x] Updated the grid layout for about section to scale according to the device aspect ratios
- [x] Removed duplicated content that was present in about-section
- [x] Fixed html structure [removed floating closing div tag]

> [!NOTE]
> Everything remains same for the wider screen devices