### PR TITLE
Add hover effect on `Become a partner` Button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,7 +27,7 @@
   --white: hsl(0, 0%, 100%);
   --black: hsl(0, 0%, 0%);
   --jet: hsl(0, 0%, 18%);
-
+  --pistachio_100: rgb(73, 123, 7);
   /**
    * typography
    */
@@ -219,9 +219,17 @@ body {
 
 .btn-secondary:is(:hover, :focus) { --btn-bg: var(--pistachio); }
 
-.btn-outline {
-  border: 2px solid var(--white);
-  background-color: transparent;
+.btn-outline { --btn-bg: var(--pistachio_100); }
+
+.btn-outline:is(:hover, :focus) { --btn-bg: var(--pistachio_100); }
+
+.btn-outline::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--btn-bg, var(--white));
+  transform: translate(5px, 5px);
+  transition: var(--transition-2);
 }
 
 .btn-white {


### PR DESCRIPTION
- [x] Fixes issue #168 that was assigned to me. 
- [x] Add new color `--pistachio_100: rgb(73, 123, 7);`

Previously it was like this with no hover effect
![Screenshot from 2024-10-03 17-54-23](https://github.com/user-attachments/assets/cf108b59-82a5-4871-ae47-a3c30f20abfc)

After
![Screencastfrom3-10-2405550806-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/81eb6e69-70ab-46f4-a46f-560d353cce8d)

@anuragverma108 please review this pr.