### PR TITLE
GitHub icon and link added at line no.1217 #394

### DIFF
--- a/new.html
+++ b/new.html
@@ -1214,7 +1214,7 @@
           <a href="#"><ion-icon name="logo-instagram"></ion-icon></a>
           <a href="#"><ion-icon name="logo-linkedin"></ion-icon></a>
           <a href="#"><ion-icon name="logo-youtube"></ion-icon></a>
-          <a href="new.html"><ion-icon name="logo-github"></ion-icon></a>
+          <a href="https://github.com/anuragverma108/WildGuard"><ion-icon name="logo-github"></ion-icon></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR adds a GitHub link to the footer section within the class="footer-social-icons", allowing users to easily access the WildGuard GitHub repository. By clicking on the GitHub icon, users will be redirected to the repository.

Before:
![Screenshot 2024-10-03 225538](https://github.com/user-attachments/assets/baec8705-54e8-4629-adc0-2a6ff24d1b14)
 
After:

https://github.com/user-attachments/assets/73c0dc46-7f1f-4e79-bb7d-eab5a7f5057f

 