### PR TITLE
fixed menu bg on small screen

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -361,13 +361,15 @@ body {
 }
 
 .navbar-list {
-  max-width: 400px;
+  max-width: 300px;
   width: 100%;
   margin: auto;
+  padding-top: 20px;
   padding-inline: 10px;
   opacity: 0;
   transition: 0.5s ease;
   transition-delay: 0s;
+  background-color:hsla(0, 0%, 0%, 0.8) ;
 }
 
 .navbar.active .navbar-list {


### PR DESCRIPTION
#667 

added background to nav menu on hamburger when screen size get smaller 
so that it wont be hidden on white bg.
 
![Screenshot (259)](https://github.com/user-attachments/assets/384a7fad-3e2d-4e35-b3cc-0c3a57b32078)
