### PR TITLE
Fix Progress Bar Layout Issue

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -292,6 +292,7 @@ body {
 .header.active {
   background-color: var(--eerie-black-1);
   box-shadow: 0 0 10px hsla(0, 0%, 0%, 0.8);
+  padding: 0px;
 }
 
 .header.active::after { display: none; }
@@ -1419,7 +1420,7 @@ body {
 .progress-bar {
   margin-top: 0px;
   width: 100%;
-  height: 1vh;
+  height: 0.2vh;
   margin-top: 0px;
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -192,10 +192,10 @@ body {
   background-color: var(--btn-bg, var(--pistachio));
   color: var(--white);
   font-weight: var(--fw-600);
-  padding: 12px 32px;
+  padding: 10px 10px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 1px;
   transition: var(--transition-2);
 }
 


### PR DESCRIPTION
**Description:**

Resolves layout issue causing blank space before progress bar.

**Fixes - #704** 

**Changes:**

Adjusted CSS styling for the progress bar container to remove unnecessary space.

Here is the updated progress bar -
![image](https://github.com/user-attachments/assets/0990a4c9-fdc6-4f40-bf45-fe17ec155208)

**Testing:**
Verified fix on Chrome (Version 129.0.6668.90), and Windows 10.

Checklist:
- [x] Verified fix resolves layout issue.