### PR TITLE
Removed the duplicate part and aligned the text and links in footer

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1408,7 +1408,7 @@ body {
 .footer-bottom {
   background-color: #0f0f0f;
   text-align: center;
-  padding: 25px 0;
+  padding: 20px 0;
   font-size: 1.3rem;
   width: 100%;
   display: flex;
@@ -1438,11 +1438,19 @@ body {
 }
 .footer-box{
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
 }
+.footer-left {
+  position: relative;
+  right: -10px;
+}
 .footer-bottom p, .footer-bottom ul {
   margin: 0;
+}
+.footer-box .container {
+  margin: 0px;
 }
 
 .footer-bottom a {
@@ -1469,6 +1477,7 @@ body {
 .footer-right {
   text-align: right;
 }
+
 
 
 

--- a/index.html
+++ b/index.html
@@ -1246,7 +1246,7 @@
       </div>
     </div>
     
-<div class="footer-bottom">
+<!-- <div class="footer-bottom">
   <p>Copyright 2024 <a href="https://wildguard.netlify.app/">WildGuard</a> All Rights Reserved</p>
   <div class="container">
     <ul class="footer-list">
@@ -1258,7 +1258,7 @@
       </li>
     </ul>
   </div>
-</div>
+</div> -->
 
 
     <div class="footer-bottom">


### PR DESCRIPTION
In footer section, removed the existing duplicate part and adding a copyright symbol as well as splitting the text part into two lines and moving the links to the bottom to make the footer look neat.