### PR TITLE
Remove Duplicate Footer and Update Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1245,19 +1245,18 @@
         </div>
       </div>
     </div>
-
-
+    
     <div class="footer-bottom">
       <div class="footer-box">
         <div class="container">
-          <p>Copyright 2024 WildGuard. All Rights Reserved</p>
+          <p>© 2024 WildGuard. All Rights Reserved.</p>
         </div>
-        <div class="footer-left">
+        <!-- <div class="footer-left">
           <ul class="footer-list">
             <li><a href="./terms-of-use.html" class="footer-link">Terms of use</a></li>
             <li><a href="./privacy-policy.html" class="footer-link">Privacy & Policy</a></li>
           </ul>
-        </div>
+        </div> -->
         <!-- <div class="footer-right">
             <!-- <p>Copyright 2024 <a href="#" class="copyright-link">Anurag Bytes</a>All Rights Reserve</p> -->
       </div>

--- a/index.html
+++ b/index.html
@@ -1245,20 +1245,6 @@
         </div>
       </div>
     </div>
-    
-<div class="footer-bottom">
-  <p>Copyright 2024 <a href="https://wildguard.netlify.app/">WildGuard</a> All Rights Reserved</p>
-  <div class="container">
-    <ul class="footer-list">
-      <li>
-        <a href="./terms-of-use.html" class="footer-link">Terms of use</a>
-      </li>
-      <li>
-        <a href="./privacy-policy.html" class="footer-link">Privacy & Policy</a>
-      </li>
-    </ul>
-  </div>
-</div>
 
 
     <div class="footer-bottom">


### PR DESCRIPTION
### Summary
- Removed the duplicate footer section from the website.
- Removed the Terms of Use and Privacy Policy links in the footer, as they are already included in the Quick Links section above.

### Details
- The footer now contains only the copyright notice for a cleaner layout.
- This change enhances the user experience by eliminating redundancy.

### Before and After
- **Before**: 
![image](https://github.com/user-attachments/assets/8e2a9904-750e-4221-9d46-ff775d0a1210)

- **After**: 
![image](https://github.com/user-attachments/assets/c2562f45-afb1-4111-acae-f0a0b5508ada)


### Additional Notes
- No functional changes were made to the site's behavior.
