### PR TITLE
Bottom Footer and Redundant Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,11 +1224,7 @@
             <li><a href="#about">About</a></li>
             <li><a href="#service">Service</a></li>
             <li><a href="#donate">Donate</a></li>
-          </ul>
-          <ul>
             <li><a href="./Contact.html">Contact Us</a></li>
-            <li><a href="./terms-of-use.html">Terms of Use</a></li>
-            <li><a href="./privacy-policy.html">Privacy Policy</a></li>
           </ul>
         </div>
       </div>
@@ -1248,19 +1244,14 @@
       </div>
     </div>
     
-<div class="footer-bottom">
-  <p>Copyright 2024 <a href="copyright.html">WildGuard</a> All Rights Reserved</p>
-  <div class="container">
-    <ul class="footer-list">
-      <li>
-        <a href="./terms-of-use.html" class="footer-link">Terms of use</a>
-      </li>
-      <li>
-        <a href="./privacy-policy.html" class="footer-link">Privacy & Policy</a>
-      </li>
-    </ul>
-  </div>
-</div>
+    <div class="footer-bottom" style="display: inline;">
+      <p>© 2024 <a href="copyright.html" style="display: inline;">WildGuard</a> All Rights Reserved</p>
+      <p>
+        <a href="./terms-of-use.html" class="footer-link" style="display: inline;">Terms of Service</a> | 
+        <a href="./privacy-policy.html" class="footer-link" style="display: inline;">Privacy Policy</a>
+      </p>
+    </div>
+
 
 
   </footer>


### PR DESCRIPTION
This pull request addresses the issues outlined in #736 by implementing the following changes:

- Updated the copyright text to include the proper copyright symbol (©).
- Removed the "Terms of Use" and "Privacy Policy" links from the quick links section to eliminate redundancy.
- Improved alignment and spacing at the bottom of the footer for a cleaner look.

Before: 
![image](https://github.com/user-attachments/assets/29f90f07-a33e-4f7b-bf45-7e42d2897762)

After: 
![image](https://github.com/user-attachments/assets/4977577a-250c-40c5-881b-caf923390955)

