### PR TITLE
Fix Redirect for Register Link

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,12 +142,19 @@
             </a>
           </li>
           
-          <li>
-            <a class="navbar-link login-nav" id="openPopup" data-nav-link>
-              <span>Register</span>
-              <ion-icon name="chevron-forward-outline" aria-hidden="true"></ion-icon>
-            </a>
-          </li>
+          <a id="registerLink" class="navbar-link login-nav" href="register.html" data-nav-link>
+            <span>Register</span>
+            <ion-icon name="chevron-forward-outline" aria-hidden="true"></ion-icon>
+          </a>
+          
+          <script>
+          document.getElementById('registerLink').addEventListener('click', function(e) {
+            e.preventDefault();
+            window.location.href = 'register.html';
+          });
+          </script>
+          
+          
 
         </ul>
 


### PR DESCRIPTION
 
Issue Addressed: Users were unable to navigate to the registration page when clicking the "Register"
 link in the navigation bar.
This implementation ensures that the registration link works as intended and improves the user experience by directing them to the correct page upon clicking the link.

Testing:

Click the "Register" link in the navbar to confirm it successfully redirects to the registration page without any issues.