### PR TITLE
Update copyright.html in the third party content section

### DIFF
--- a/copyright.html
+++ b/copyright.html
@@ -92,8 +92,10 @@
 
         <h2>Third-Party Content</h2>
         <p>
-            WildGuard may include links to third-party websites or display third-party content. We are not responsible 
-            for the content, copyright policies, or practices of third-party sites.
+            WildGuard may include links to third-party websites, display third-party content, or incorporate services 
+            provided by third-party entities. We provide these links and content for your convenience and information. 
+            However, we do not endorse, control, or assume any responsibility for the content, accuracy, privacy policies, 
+            copyright policies, terms of service, or practices of these third-party sites or services.
         </p>
 
         <h2>Changes to This Policy</h2>


### PR DESCRIPTION
current third party content section states :
"WildGuard may include links to third-party websites or display third-party content. We are not responsible for the content, copyright policies, or practices of third-party sites."


Request to approve the change of above content to :
"
WildGuard may include links to third-party websites, display third-party content, or incorporate services
provided by third-party entities. We provide these links and content for your convenience and information.
However, we do not endorse, control, or assume any responsibility for the content, accuracy, privacy policies,
copyright policies, terms of service, or practices of these third-party sites or services.
"

Thanks,
Maninder