### PR TITLE
Changed margin of Wildlife conversation fourm from (0 auto) to (20px auto) #893

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -73,7 +73,7 @@
 }
 .container_1 {
   max-width: 800px;
-  margin: 0 auto;
+  margin: 20px auto;
   background-color: white;
   padding: 20px;
   border-radius: 8px;


### PR DESCRIPTION
I have updated the margin of the Wildlife Conservation Forum section from margin: 0 auto to margin: 20px auto. This adjustment improves the visual spacing between the "Wildlife Conservation Forum" section and the adjacent sections, making the layout more readable and aesthetically pleasing.

Changes made:
Modified the margin from 0 auto to 20px auto in the respective CSS/stylesheet file.
How this helps:
Enhances the visual separation between sections.
Improves the readability and overall user experience on the site.


![Screenshot (4)](https://github.com/user-attachments/assets/0e650e23-8918-4072-8e4a-7204b75d9320)
![Screenshot (5)](https://github.com/user-attachments/assets/27182d87-25aa-43e6-be17-cfe6e806ebdb)
![Screenshot (6)](https://github.com/user-attachments/assets/30df48a9-4ce1-4c79-99e5-988725715f0e)
