### PR TITLE
Improved the size of the profile picture in the testimonial section and aligned the photo properly with the text and the author name #895

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1168,6 +1168,9 @@ body {
 
 .testi-content {
   padding: var(--section-padding) 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .testi .section-title {
@@ -1182,6 +1185,8 @@ body {
 .testi-text,
 .testi-name {
   font-size: var(--fs-8);
+  font-size: 16px;
+  line-height: 1.5;
 }
 
 .testi-text,
@@ -1203,7 +1208,12 @@ body {
 .testi-banner {
   background-color: var(--light-gray);
 }
-
+.testi-cover {
+  width: 80px;  /* Increased from 60px to 80px */
+  height: 80px; /* Increased from 60px to 80px */
+  border-radius: 50%;
+  object-fit: cover;
+}
 /*-----------------------------------*\
   #PARTNER
 \*-----------------------------------*/

--- a/index.html
+++ b/index.html
@@ -940,7 +940,9 @@
           <div class="testi-card">
 
             <figure class="card-avatar">
-              <img src="./assets/images/testi-avatar.png" width="60" height="60" loading="lazy" alt="David S. Neuman">
+              <div class="testi-cover">
+                <img src="./assets/images/testi-avatar.png" width="100" height="100" loading="lazy" alt="David S. Neuman">
+              </div>
             </figure>
 
             <div>


### PR DESCRIPTION
Enhance testimonial layout: Increase profile picture size and improve text alignment

- Increased profile picture dimensions from 60px to 80px
- Adjusted testimonial content layout for better vertical alignment
- Refined text styling for improved readability and proportion
- Positioned author info at the bottom for better overall balance

Old Testimonial section:
<img width="599" alt="Screenshot 2024-10-11 at 12 01 32 PM" src="https://github.com/user-attachments/assets/786f2c38-19c3-432b-830f-43be0f17c03d">

Updated Testimonial Section:
<img width="554" alt="Screenshot 2024-10-11 at 12 42 41 PM" src="https://github.com/user-attachments/assets/3a2a6fb2-364e-4215-be61-5c021238ea96">
