### PR TITLE
#911 redirects the user to registration portal on cliciking on the register option in the navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
           </li>
           
           <li>
-            <a class="navbar-link login-nav" id="openPopup" data-nav-link>
+            <a class="navbar-link login-nav" id="openPopup" onclick="location.href='register.html';" data-nav-link>
               <span>Register</span>
               <ion-icon name="chevron-forward-outline" aria-hidden="true"></ion-icon>
             </a>


### PR DESCRIPTION
#911 fixed the registration option in the navbar as now on clicking on the register option in the navbar it redirects the user to the registration portal.

https://github.com/user-attachments/assets/316a747e-ad62-42a6-8c99-a9fc20f91eb8

i would sincerely request you to merge this pull request as it is a very useful change to the website as the register option isnt working in the website as of now.