### PR TITLE
[fixes]: Restrict Name Input to Alphabetic Characters Only

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -136,8 +136,9 @@
             <div class="form-group">
                 <label for="name">Full Name:</label>
                 <input type="text" class="form-control" id="name" name="name" placeholder="Enter your full name"
-                    required>
+                       pattern="[A-Za-z\s]+" title="Please enter Full Name" required>
             </div>
+            
             <div class="form-group">
                 <label for="email">Email Address:</label>
                 <input type="email" class="form-control" id="email" name="email" placeholder="Enter your email"

--- a/donate.html
+++ b/donate.html
@@ -136,8 +136,9 @@
             <div class="form-group">
                 <label for="name">Full Name:</label>
                 <input type="text" class="form-control" id="name" name="name" placeholder="Enter your full name"
-                       pattern="[A-Za-z\s]+" title="Please enter Full Name" required>
+                       pattern="[A-Za-z\s]+" title="Please enter alphabets only" required>
             </div>
+            
             
             <div class="form-group">
                 <label for="email">Email Address:</label>


### PR DESCRIPTION
fixes : #957 issue 

**Why This Change Is Needed:**

This improves the user experience by ensuring that only valid names can be entered in the form.
It prevents users from accidentally submitting numbers or special characters, which are typically not part of a valid name.

**Testing:**

Verified that the input now only accepts alphabetic characters and spaces.
Ensured that an error message is displayed if the user tries to input invalid characters, and form submission is prevented.

![image](https://github.com/user-attachments/assets/0869ce94-bc40-4795-8dc8-952f191d8d76)
