### PR TITLE
 Fix Navbar Logo Color on Scroll (#990)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -25,6 +25,7 @@
   --black: hsl(0, 0%, 0%);
   --jet: hsl(0, 0%, 18%);
   --pistachio_100: rgb(73, 123, 7);
+  --green: #28a745;
   /**
    * typography
    */
@@ -394,7 +395,7 @@ body {
 }
 
 .logo {
-  color: var(--white);
+  color: var(--green);
   font-family: var(--ff-oswald);
   font-size: 3.2rem;
   text-transform: uppercase;


### PR DESCRIPTION
This pull request solves the issue where the navbar logo would blend into the background on scroll due to both having the same white color. I have updated the CSS to change the logo color to green when scrolling.

Before:

The logo blends into the background when scrolling, making it invisible:
![Screenshot_20241013_175535](https://github.com/user-attachments/assets/a4af1ba9-7924-46db-a6f2-dfc795f41705)



After:

The logo now changes color to green when scrolling, ensuring it remains visible:
![Screenshot_20241013_181338](https://github.com/user-attachments/assets/a2fe7e42-b128-4fee-b7dd-0347b777e917)



Fix Details:

Added the following CSS to change the logo color when the navbar becomes active on scroll:

     .logo {
         color: var(--green);
     }


Closes Issue: #990