### PR TITLE
#997 clicking on donate now under the 'support us with your donations' section redirects to donation website

### DIFF
--- a/index.html
+++ b/index.html
@@ -495,27 +495,27 @@
     <div class="card">
      <b> <h2>Basic Tier</h2></b>
       <p class="amount">$10/month</p>
-      <p class="donate-button">Donate Now</p>
+      <p onclick="location.href='Donation.html';" class="donate-button">Donate Now</p>
 
     </div>
     <div class="card">
       <b><h2>Supporter Tier</h2></b>
       <p class="amount">$25/month</p>
       <p class="benefits">All Basic Tier benefits<br>Personalised thank-you message</p>
-      <button class="donate-button">Donate Now</button>
+      <button onclick="location.href='Donation.html';" class="donate-button">Donate Now</button>
     </div>
     <div class="card">
       <b><h2>Champion Tier</h2></b>
       <p class="amount">$50/month</p>
       <p class="benefits">All Suppoeter Tier benefits<br>Quarterly report on our impact</p>
-      <button class="donate-button">Donate Now</button>
+      <button onclick="location.href='Donation.html';" class="donate-button">Donate Now</button>
     </div>
     
     <div class="card">
       <b><h2>Leader Tier</h2></b>
       <p class="amount">$100/month</p>
       <p class="benefits">All Champion Tier benefits<br>Invitation to exclusive events</p>
-      <button class="donate-button">Donate Now</button>
+      <button onclick="location.href='Donation.html';" class="donate-button">Donate Now</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#997 clicking on donate now under the support us with you donations section redirects to donation website 

https://github.com/user-attachments/assets/890b030c-1042-4137-aca4-743147ba3f03

added this redirection to all donate now buttons it would be of great help for the users willing to donate so please add this change 