### PR TITLE
Cursor Pointer Not Displayed on Hover for Tree Plantation Card

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1178,6 +1178,10 @@ html {
   text-decoration: underline;
 }
 
+.btn-link span:hover{
+  cursor: pointer;
+}
+
 #service-card1 {
   transition: transform 0.3s ease;
 }


### PR DESCRIPTION
The issue where the cursor pointer was not displaying on hover for the **Tree Plantation** card has been resolved. Previously, while the hover effect was working correctly for all other cards, the **Tree Plantation** card failed to display the cursor pointer, impacting user interactivity.

#### Solution:
The issue was fixed by adding the necessary **hover** effect for the Tree Plantation card in the `style.css` file. Now, the cursor changes to a pointer on hover, consistent with the behavior of other cards.

![WhatsApp Image 2024-10-14 at 22 28 11_a9d2d40c](https://github.com/user-attachments/assets/d7c7c642-72db-4f00-bbc4-69d1ef6f4842)
