### PR TITLE
Added navbar link to Statistics section in save ecology page #1123 

### DIFF
--- a/SaveEcology.html
+++ b/SaveEcology.html
@@ -21,7 +21,7 @@
                     <li><a href="#solutions">Solutions</a></li>
                     <li><a href="#impact">Impact</a></li>
                     <li><a href="#how-to-help">How to Help</a></li>
-                    <li><a href="#stats">Stats</a></li>
+                    <li><a href="#statistics">statistics</a></li>
                     <li><a href="#contact">Contact</a></li>
                 </ul>
             </nav>


### PR DESCRIPTION
In save ecology section, before in the navbar "stats" wasn't linked to its actual page.After the changes it is linked with a modified name "statistics".