### PR TITLE
login page linked

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,13 @@
             </a>
           </li>
 
+          <script>
+            document.getElementById('openPopup').addEventListener('click', function (e) {
+              e.preventDefault(); // Prevent default anchor behavior
+              window.location.href = 'login.html'; // Redirect to the login page
+            });
+          </script>
+
           <a id="registerLink" class="navbar-link login-nav" href="register.html" data-nav-link>
             <span>Register</span>
             <ion-icon name="chevron-forward-outline" aria-hidden="true"></ion-icon>


### PR DESCRIPTION
hello @anuragverma108 

The login button with the id="openPopup" is not properly redirecting to the login.html page. The issue is due to missing event handling in JavaScript.

Proposed Solution: Add the following script to handle the click event:

<script> document.getElementById('openPopup').addEventListener('click', function (e) { e.preventDefault(); // Prevent default anchor behavior window.location.href = 'login.html'; // Redirect to the login page }); </script>
Steps to Reproduce:

Click on the login button.
Observe that the page does not navigate to login.html.
Expected Behavior: The button should redirect the user to the login.html page.

THE ISSUE IS RESOLVED 

PLEASE MERGE IT @anuragverma108 