### PR TITLE
Improved the structure of service cards #1230

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1326,6 +1326,10 @@ html {
   width: 60%;
 }
 
+.card .benefits{
+  height: 100px;
+}
+
 .donate-list > li{
   margin-bottom: 300px;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1182,8 +1182,11 @@ html {
 }
 
 .service-list {
-  display: grid;
-  gap: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  /* gap: 30px; */
 }
 
 .service-card {
@@ -2856,8 +2859,8 @@ data{
 .service-card {
   perspective: 1000px;
   cursor: pointer;
-  width: 270px; /* Adjust the width as needed */
-  height: 400px; /* Adjust the height as needed */
+  width: 300px; /* Adjust the width as needed */
+  height: 500px; /* Adjust the height as needed */
   margin: 20px; /* Add some margin around the card */
 }
 
@@ -2876,7 +2879,9 @@ data{
 .card-text {
   font-size: 1em; /* Text font size */
   text-align: center; /* Center align text */
-  margin: 10px 0; /* Space above and below the text */
+  /* margin: 10px 0; Space above and below the text */
+  height: 120px;
+  padding: 0 7px;
 }
 
 .btn-link {

--- a/index.html
+++ b/index.html
@@ -611,9 +611,9 @@
             We Work Differently to <strong>keep The World Safe</strong>
           </h2>
 
-          <ul class="service-list">
+          <div class="service-list">
 
-            <li>
+            <div>
               <div class="service-card" id="service-card1">
                   <div class="card-inner">
                       <div class="card-front">
@@ -640,9 +640,9 @@
                       </div>
                   </div>
               </div>
-          </li>
+            </div>
 
-          <li>
+          <div>
             <div class="service-card" id="service-card2">
                 <div class="card-inner">
                     <div class="card-front">
@@ -669,9 +669,9 @@
                     </div>
                 </div>
             </div>
-        </li>
+          </div>
     
-        <li>
+        <div>
             <div class="service-card" id="service-card3">
                 <div class="card-inner">
                     <div class="card-front">
@@ -698,9 +698,9 @@
                     </div>
                 </div>
             </div>
-        </li>
+          </div>
     
-        <li>
+        <div>
             <div class="service-card" id="service-card4">
                 <div class="card-inner">
                     <div class="card-front">
@@ -727,9 +727,9 @@
                     </div>
                 </div>
             </div>
-        </li>
+          </div>
 
-          </ul>
+        </div>
 
         </div>
       </section>


### PR DESCRIPTION
I have improved the alignment and structure of service cards . 
I have corrected the positioning of icons , readmore button , text.
I have also improved the service card for large screen size the service cards should come in next line if the screen size is bigger.
Before:
![image](https://github.com/user-attachments/assets/e119d3b8-7b1d-4eb2-8a7c-89198295c037)

for large screen size 4th card is missing 

![image](https://github.com/user-attachments/assets/46c68010-3fc4-41d3-a988-3cbb81efcde9)


After:
![image](https://github.com/user-attachments/assets/d1fa2b91-a5da-41d2-b063-79e5303cfc7b)

for large screen size 4th service card shifts to the next line automatically.

![image](https://github.com/user-attachments/assets/e8bae22c-d012-48eb-8408-b0f60b445237)



