### PR TITLE
Improved Hover Transition in back cover

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3010,7 +3010,8 @@ data {
 }
 
 .service-card:hover .card-inner {
-  animation: rotateCard 2s forwards;
+  /*animation: rotateCard 2s forwards;*/
+  transform: rotateY(180deg);
 }
 
 @keyframes rotateCard {


### PR DESCRIPTION
Previous Implementation of animated made back cover text unable to read as animations works for 2sec. so i created changes so that back cover is shown until the element is hovered.

before

https://github.com/user-attachments/assets/8c2d7e32-e80a-43f6-9590-b72ef7d149b1

after

https://github.com/user-attachments/assets/838c5f27-ddc5-4ef9-b8f7-ed9afd7b5f3e

please add hacktoberfest label.

