### PR TITLE
Fix: Correct capitalization of "Y" in New York and adjust grammar in description

### DIFF
--- a/index.html
+++ b/index.html
@@ -1344,11 +1344,10 @@ Our mission is to provide outstanding care and dedicated support for animals in 
                       <div class="card-content">
                         <p class="card-subtitle">Animal Shelter Fundraiser</p>
 
-                        <h3 class="card-title">Rivereside park, New york </h3>
+                        <h3 class="card-title">Rivereside park, New York </h3>
 
                         <p class="card-text">
-                          This hot summer have been a nightmare for roadside animals to help the roadside animals we are
-                          raising shelter funds.
+                          This hot summer has been a nightmare for roadside animals. To help them, we are raising shelter funds.
                         </p>
                       </div>
 


### PR DESCRIPTION
This issue addresses two main changes:
1. **Capitalization**: The "y" in "New York" was incorrectly lowercase, which has been corrected to an uppercase "Y".
2. **Grammar improvement**: The original sentence lacked proper punctuation and flow. Specifically, the phrase **"This hot summer have been"** was changed to **"This hot summer has been"** to correct subject-verb agreement.

### Screenshots:

- Before: 

![image](https://github.com/user-attachments/assets/9f11c11d-51cc-4132-8577-26bfa1078f9a)

- After:

![image](https://github.com/user-attachments/assets/b88f5695-5eb4-428b-a260-ad7164e1daaf)

Thank you!