### PR TITLE
Add margin between the Donation button and the line above (#1461)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -861,6 +861,7 @@ html {
   justify-content: center;
   /* Center horizontally */
   align-items: center;
+  margin-top: 30px;
 }
 
 /*-----------------------------------*\ 


### PR DESCRIPTION
This pull request addresses issue #1461, where the Donation button and the text above it were too close, affecting the visual layout. To resolve this, a margin has been added above the button, ensuring there is sufficient spacing for improved readability and aesthetics.

Screenshots:--

Before:
![Screenshot_20241021_144359](https://github.com/user-attachments/assets/a0e8cd2b-9589-4dd5-adb4-5dc665176a59)


After:
![Screenshot_20241021_145625](https://github.com/user-attachments/assets/f8667a28-01ef-4d49-ae39-7008384438d7)
