### PR TITLE
Poor resolution of image in flip.container fixed with better image

### DIFF
--- a/Contact.html
+++ b/Contact.html
@@ -346,7 +346,7 @@
         <!-- Front: Image -->
         <div class="front">
           <img
-            src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcReHDIAZtYGPU6V1mgi0NgGklFupj5RDAIGTnr6Bj8fskpbCDy3wiqZCDx5kmMXqFUrDuo&usqp=CAU"
+            src="https://i.pinimg.com/736x/53/f5/53/53f553136c1dc13c3fcc0dfcc9dcfb9a.jpg"
             alt="Wild Animal">
         </div>
         <!-- Back: Contact Information -->


### PR DESCRIPTION
The url for the image in the flip.container div had a poor resolution which has been fixed with a new image.

Before:- 
![Screenshot from 2024-10-22 18-16-50](https://github.com/user-attachments/assets/48561f12-a40d-413d-9be9-930f6e6ffb3c)

After:- 
![Screenshot from 2024-10-22 18-17-27](https://github.com/user-attachments/assets/2c2465e2-213c-4c91-b728-5002a33e7173)


