### PR TITLE
Adjusted the z-index of the scroll down button. Solve#1521

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
    document.head.appendChild(style);
 </script>
 
-<div class="scroll-to-bottom">
+<div class="scroll-to-bottom" style="position: fixed; z-index: 1000000;">
   <button id="scrollBOTTOM">
     <i class="material-icons">arrow_downward</i>
   </button>


### PR DESCRIPTION
Adjusted the z-index of the scroll down button to ensure it appears above other elements. This resolves the issue where the button was not clickable in certain scenarios.
Before
![before](https://github.com/user-attachments/assets/39fbd354-d120-4046-b56a-3165dd84b7da)
**After**
![after](https://github.com/user-attachments/assets/d269b12a-864b-46a0-9f4f-e92fa61c7439)
