### PR TITLE
Fix Dropdown Menu Visibility Issue Over Scroll-to-Bottom Button #1547

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
    document.head.appendChild(style);
 </script>
 
-<div class="scroll-to-bottom" style="position: fixed; z-index: 900;">
+<div class="scroll-to-bottom" style="position: fixed; z-index: 100;">
   <button id="scrollBOTTOM">
     <i class="material-icons">arrow_downward</i>
   </button>


### PR DESCRIPTION
This PR resolves the issue where the dropdown menu of the profile icon gets hidden behind the "Scroll to Bottom" button when hovered. #1547 

Fixes:
1. Adjusted the z-index of the dropdown menu to ensure it appears above the "Scroll to Bottom" button, allowing the entire content to be fully visible.
2. Tested the hover behavior to ensure smooth interaction and visibility of the dropdown menu.

With this fix, the dropdown menu no longer gets hidden, enhancing the overall user experience.

Before:
![image](https://github.com/user-attachments/assets/351a3b00-696b-4288-94ce-64b822fb631b)

After:
![image](https://github.com/user-attachments/assets/023637f6-5216-4c5c-85c8-d3213afa081e)
