### PR TITLE
Fix Duplicate "Read More" Buttons in Cards.

### DIFF
--- a/index.html
+++ b/index.html
@@ -833,10 +833,7 @@ Our mission is to provide outstanding care and dedicated support for animals in 
                       </div>
                       
                   </div>
-                  <a href="SaveNature.html" class="btn-link">
-                    <span>Read More</span>
-                    <ion-icon name="arrow-forward" aria-hidden="true"></ion-icon>
-                  </a>
+                  
               </div>
             </div>
 
@@ -867,10 +864,6 @@ Our mission is to provide outstanding care and dedicated support for animals in 
                         </a>
                     </div>
                 </div>
-                <a href="SaveEcology.html" class="btn-link">
-                  <span>Read More</span>
-                  <ion-icon name="arrow-forward" aria-hidden="true"></ion-icon>
-              </a>
             </div>
             
           </div>
@@ -902,10 +895,7 @@ Our mission is to provide outstanding care and dedicated support for animals in 
                         </a>
                     </div>
                 </div>
-                <a href="TreePlantation.html" class="btn-link">
-                  <span>Read More</span>
-                  <ion-icon name="arrow-forward" aria-hidden="true"></ion-icon>
-              </a>
+                
             </div>
           </div>
     
@@ -936,10 +926,7 @@ Our mission is to provide outstanding care and dedicated support for animals in 
                         </a>
                     </div>
                 </div>
-                <a href="SaveOcean.html" class="btn-link">
-                  <span>Read More</span>
-                  <ion-icon name="arrow-forward" aria-hidden="true"></ion-icon>
-              </a>
+                
             </div>
           </div>
 

--- a/style_changed.css
+++ b/style_changed.css
@@ -634,7 +634,7 @@ body {
 .service-card {
   background-color: var(--white);
   text-align: center;
-  padding: 45px 40px;
+  padding: 40px 40px;
   border-radius: 2px;
   outline: 3px solid transparent;
   box-shadow: var(--card-shadow);


### PR DESCRIPTION
Description:
This PR addresses the issue of duplicate "Read More" buttons in the card sections (Save Nature, Save Ecology, Tree Plantation, and Thank You!). The extra button has been removed to streamline the user interface and improve usability. Now, each card contains only one "Read More" button.

Related Issue:
Fixes #1549  - Duplicate "Read More" buttons in all cards.

Changes Made:

Removed the redundant "Read More" button from all cards.
Ensured that each card only has a single, functional "Read More" button.

Before Changes (Screenshot):
![WhatsApp Image 2024-10-25 at 01 55 38_3da19353](https://github.com/user-attachments/assets/fa337a3a-7209-443a-bf7a-ae363fa852f8)


After Changes (Screenshot):
![Screenshot 2024-10-25 031526](https://github.com/user-attachments/assets/f88f9e95-48fe-4b75-9400-06e5eac83d6c)
