### PR TITLE
fixed issue #1572

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1368,7 +1368,7 @@ html {
 
 .btn-link span {
   
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 .btn-link span:hover {


### PR DESCRIPTION
**Description:**
This PR addresses an issue #1572  with the "Read More" button in the service section of the `index.html` file. The button previously had an unwanted text-decoration underline, which did not match the design style. The following change was made:

- Removed the` text-decoration underline` from the "Read More" button, setting it to `none` for a cleaner and more professional appearance.

This update enhances the visual consistency of the button and aligns it with the overall styling of the website.

fix issue #1572 


**Before:**

![Screenshot 2024-10-26 202155](https://github.com/user-attachments/assets/4ac1f38d-13eb-4f28-b9eb-3170cd72a6d3)

**After:**

![Screenshot 2024-10-26 204034](https://github.com/user-attachments/assets/a9aa9536-9d25-48d7-8647-c47b3edb9b78)

**Checklist:**
- [x] Verified that the "Read More" button now has no text underline.
- [x] Tested the changes across different screen sizes to ensure consistency.
- [x] Checked for any unexpected style changes or regressions.